### PR TITLE
[LA-10770] API docs for channel progress endpoints

### DIFF
--- a/source/includes/_channels.md
+++ b/source/includes/_channels.md
@@ -65,3 +65,108 @@ Response will be paginated [see pagination](#pagination)
 }
 
 ```
+
+## Users Progress
+
+> View progress of all assigned users through a specified channel:
+
+```shell
+curl --location --request GET 'https://api.learnamp.com/v1/channels/123/users_progress' \
+--header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
+```
+
+```ruby
+module Learnamp
+  class Channels
+    include HTTParty
+    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+
+    attr_accessor :token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def users_progress(id)
+      response = self.class.get("/channels/#{id}/users_progress", { headers: headers })
+      response.parsed_response
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{token}"
+      }
+    end
+  end
+end
+
+data = Learnamp::Channels.new(token).users_progress(123)
+```
+
+View progress of all assigned users through a specified channel. This is analogous to Learn Amp's Content Log feature, for a single channel.
+
+`GET https://api.learnamp.com/v1/channels/{channelId}/users_progress`
+
+This end-point will return a paginated array of users who are assigned the specified channel. Each element will contain the completion percentage of the channel by that user, as well as the datetime (if any) when the channel was completed.
+
+Please note: Only assigned users will be returned. Users who are not assigned the specified channel will not appear in the array.
+
+Also, please note: The completion percentage is a cached value, which is refreshed in the background automatically. The completion percentage shown may therefore take a few minutes to update.
+
+The results are ordered alphabetically by user's last name.
+
+Response will be paginated [see pagination](#pagination)
+
+> 200 OK - successful response:
+
+```json
+[
+    {
+        "user_id": 200321,
+        "first_name": "John",
+        "last_name": "Abc",
+        "email": "jabc@test.com",
+        "content_name": "Favourites",
+        "content_type": "Channel",
+        "content_id": 1,
+        "completed": false,
+        "completion_percent": 50,
+        "completed_at": null
+    },
+    {
+        "user_id": 200018,
+        "first_name": "Hannah",
+        "last_name": "Baker",
+        "email": "hbaker@test.com",
+        "content_name": "Favourites",
+        "content_type": "Channel",
+        "content_id": 1,
+        "completed": true,
+        "completion_percent": 100,
+        "completed_at": "2023-04-04T15:44:04Z"
+    },
+    {
+        "user_id": 199915,
+        "first_name": "Brian",
+        "last_name": "Cross",
+        "email": "bcross@test.com",
+        "content_name": "Favourites",
+        "content_type": "Channel",
+        "content_id": 1,
+        "completed": false,
+        "completion_percent": 0,
+        "completed_at": null
+    }
+]
+
+```
+
+> 404 Not Found - unsuccessful response when channel ID does not exist:
+
+```json
+{
+    "error": "Not found"
+}
+```

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -717,3 +717,106 @@ Delete a user, so that they can no longer login. Their data is removed.
     "error": "Not found"
 }
 ```
+
+## Channels Progress
+
+> View progress of all assigned channels by the specified user:
+
+```shell
+curl --location --request GET 'https://api.learnamp.com/v1/users/567/channels_progress' \
+--header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
+```
+
+```ruby
+module Learnamp
+  class Users
+    include HTTParty
+    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+
+    attr_accessor :token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def channels_progress(user_id)
+      response = self.class.get("/channels/#{user_id}/users_progress", { headers: headers })
+      response.parsed_response
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{token}"
+      }
+    end
+  end
+end
+
+data = Learnamp::Users.new(token).Channels_progress(123)
+```
+
+View progress of all assigned channels by a specified user. This is analogous to Learn Amp's People Log feature, for a single user.
+
+`GET https://api.learnamp.com/v1/users/{userId}/channels_progress`
+
+This end-point will return a paginated array of channels that are assigned to the specified user. Each element will contain the completion percentage of the channel by that user, as well as the datetime (if any) when the channel was completed.
+
+Please note: The completion percentage is a cached value, which is refreshed in the background automatically. The completion percentage shown may therefore take a few minutes to update.
+
+The results are ordered alphabetically by created at date of the channel, most recent first.
+
+Response will be paginated [see pagination](#pagination)
+
+> 200 OK - successful response:
+
+```json
+[
+    {
+        "user_id": 200321,
+        "first_name": "John",
+        "last_name": "Abc",
+        "email": "jabc@test.com",
+        "content_name": "Favourites",
+        "content_type": "Channel",
+        "content_id": 1,
+        "completed": false,
+        "completion_percent": 50,
+        "completed_at": null
+    },
+    {
+        "user_id": 200321,
+        "first_name": "John",
+        "last_name": "Abc",
+        "email": "jabc@test.com",
+        "content_name": "Compliance Training",
+        "content_type": "Channel",
+        "content_id": 2,
+        "completed": true,
+        "completion_percent": 100,
+        "completed_at": "2023-04-04T15:44:04Z"
+    },
+    {
+        "user_id": 200321,
+        "first_name": "John",
+        "last_name": "Abc",
+        "email": "jabc@test.com",
+        "content_name": "Business Essentials",
+        "content_type": "Channel",
+        "content_id": 3,
+        "completed": false,
+        "completion_percent": 0,
+        "completed_at": null
+    }
+]
+
+```
+
+> 404 Not Found - unsuccessful response when user ID does not exist:
+
+```json
+{
+    "error": "Not found"
+}
+```


### PR DESCRIPTION
Adds documentation for the new endpoints from: LA-10451 and LA-10452

![Screenshot from 2023-05-05 16-34-53](https://user-images.githubusercontent.com/589348/236503527-5ab23852-ceba-4c7e-8581-2da05ccbe726.png)
![Screenshot from 2023-05-05 16-34-36](https://user-images.githubusercontent.com/589348/236503532-4580ce63-ff4a-45e6-b5f0-8ac5db511818.png)
