### PR TITLE
Add timezones to index

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -20,6 +20,7 @@ includes:
   - verbs
   - pagination
   - errors
+  - timezones
 
 search: true
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

Adds timezones file to includes in index.

![image](https://github.com/learnamp/api-docs/assets/2847493/75a2445a-2819-4ba9-91bf-adfbe5da6d59)

Previous PR https://github.com/learnamp/api-docs/pull/12 added information about timezone param, and linked to the timezones file, which contains a list of allowed timezones.

Unfortunately, the timezones page wasn't appearing.

---

N.B. I am not able to build the repo locally, but I'm high confidence this change should be ok. I'll keep an eye on the build and revert quickly if not.