### PR TITLE
Fix link to time-zones

### DIFF
--- a/source/includes/_activities.md
+++ b/source/includes/_activities.md
@@ -72,7 +72,7 @@ expanded | true | Optional expanded json. Returns certificate and any related ex
 include_deactivated_users | true | Optional - default is false. When true activity returned by the end-point will include activity by deactivated users.
 filters[date][from] | "2021-12-31" | Date range FROM date in ISO 8601 format
 filters[date][to] | "2022-02-28" | Date range TO date in ISO 8601 format
-filters[timezone] | "UTC" | Specify Timezone by which to filter activites. See [timezones](#timezones).
+filters[timezone] | "UTC" | Specify Timezone by which to filter activites. See [timezones](#time-zones).
 filters[user_id] | 1 | User ID of user who performed the activity
 filters[team_id] | 78823 | Filter activities to users within a particular team, specified by team_id
 filters[activityable_type] | "Item,Channel,Learnlist,Quiz" | Type of learning object. Can be single value, or comma seperated list of types: any of Item,Channel,Learnlist,Quiz


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
[LA-18558](https://learnamp.atlassian.net/browse/LA-18558) Broken time zones link in API docs

Update link to time-zones, rather than timezones which was broken

[LA-18558]: https://learnamp.atlassian.net/browse/LA-18558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ