### PR TITLE
Update Team should be PUT not POST

### DIFF
--- a/source/includes/_teams.md
+++ b/source/includes/_teams.md
@@ -451,7 +451,7 @@ team = Learnamp::Teams.new(token).update(456, params)
 
 Update a Team
 
-`POST https://api.learnamp.com/v1/items`
+`PUT https://api.learnamp.com/v1/items`
 
 ### Data in Body
 


### PR DESCRIPTION
[https://learnamp.atlassian.net/browse/LA-19096](https://learnamp.atlassian.net/browse/LA-19096) 

Documentation for updating team is incorrect.  it tells the user it should be POST when it is actually PUT

POST in docs and attempting in postman
![Screenshot 2024-04-19 at 16 21 39](https://github.com/learnamp/api-docs/assets/7602996/6c550d1d-5d84-4b79-b98a-18c6862cac8e)
![Screenshot 2024-04-19 at 16 21 29](https://github.com/learnamp/api-docs/assets/7602996/676e9baa-621e-44cb-8f79-4ffab309deb3)

PUT successful in postman and is showing in the examples for the documentation


![Screenshot 2024-04-19 at 16 25 57](https://github.com/learnamp/api-docs/assets/7602996/4ba21db0-fec3-4a5c-a067-a44a577581d0)
![Screenshot 2024-04-19 at 16 25 51](https://github.com/learnamp/api-docs/assets/7602996/1ecead52-02f3-48b3-b75e-e0a03f115dc8)
