### PR TITLE
[LA-29863] Fix team update docs

### DIFF
--- a/source/includes/_teams.md
+++ b/source/includes/_teams.md
@@ -457,7 +457,7 @@ team = Learnamp::Teams.new(token).update(456, params)
 
 Update a Team
 
-`PUT https://{API_BASE_URL}/v1/items`
+`PUT https://{API_BASE_URL}/v1/teams/{teamId}`
 
 ### Required Scope
 This endpoint requires the `teams:update` scope.


### PR DESCRIPTION


Fix endpoint shown in documentation for teams update.  
<img width="1440" height="759" alt="Screenshot 2025-10-02 at 10 52 51" src="https://github.com/user-attachments/assets/c1c5025d-31aa-4337-848b-2067a7560fdc" />
