### PR TITLE
[LA-35267] Doc team extId on /api/v1/users

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -371,7 +371,9 @@ language | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, 
 jobTitle | Developer | Job title of user
 role | viewer | user's role. One of: viewer, curator, admin, hr, reporter
 primaryTeamId | 15 | Team ID of primary team [see Teams](#teams)
+primaryTeamIntegrationExternalId | "EPOS-001" | Primary team's `integrationExternalId` [see Teams](#teams). Mutually exclusive with `primaryTeamId`.
 secondaryTeamIds | [376,377] | Array of Team IDs of seconary teams
+secondaryTeamIntegrationExternalIds | ["EPOS-001","EPOS-002"] | Array of `integrationExternalId`s for secondary teams. Mutually exclusive with `secondaryTeamIds`.
 managerId | 1 | User ID of this user's Manager (override manager, not primary team manager)
 skipInvitation | true | Skip sending the user an invitation email immediately. If skipInvitation is not set, the user will be immediately sent an invitation email
 hireDate | 2021-02-28 | Employment start date for user in ISO 8601 date format
@@ -462,6 +464,27 @@ customFields | [{ name: "Employee ID", value: "12-34-56" }] | CustomFields param
 }
 ```
 
+> 400 Bad request - unknown team `integrationExternalId`:
+
+```json
+{
+    "error": "primaryTeamIntegrationExternalId must match existing teams integration external IDs",
+    "fullErrors": {
+        "primaryTeamIntegrationExternalId": [
+            "must match existing teams integration external IDs"
+        ]
+    }
+}
+```
+
+> 400 Bad request - both id-keyed and external-id-keyed team params sent:
+
+```json
+{
+    "error": "primaryTeamId, primaryTeamIntegrationExternalId are mutually exclusive"
+}
+```
+
 ## Update a user
 
 > Update an existing user:
@@ -543,7 +566,9 @@ lastName | string | User | Last name of user *(\*)*
 language | enum | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, it, nl, pt-BR, pl, ru, zh-CN, zh-TW, ja, ar
 jobTitle | string |Developer | Job title of user
 primaryTeamId | integer | 15 | Team ID of primary team [see Teams](#teams)
+primaryTeamIntegrationExternalId | string | "EPOS-001" | Primary team's `integrationExternalId` [see Teams](#teams). Mutually exclusive with `primaryTeamId`.
 secondaryTeamIds | Array(integer) | [376,377] | Array of Team IDs of seconary teams
+secondaryTeamIntegrationExternalIds | Array(string) | ["EPOS-001","EPOS-002"] | Array of `integrationExternalId`s for secondary teams. Mutually exclusive with `secondaryTeamIds`.
 managerId | integer | 1 | User ID of this user's Manager (override manager, not primary team manager)
 hireDate | date | 2021-02-28 | Employment start date for user in ISO 8601 date format
 location | string | London | Primary location of user


### PR DESCRIPTION
## Jira

[LA-35267](https://learnamp.atlassian.net/browse/LA-35267)

## What

Documents the new team-by-`integrationExternalId` params on the public Grape v1 Users API, added in learnamp/learnamp#22631.

- New rows in the Create-user and Update-user body tables:
  - `primaryTeamIntegrationExternalId` (String) — mutually exclusive with `primaryTeamId`.
  - `secondaryTeamIntegrationExternalIds` (Array[String]) — mutually exclusive with `secondaryTeamIds`.
- New 400 examples on `POST /api/v1/users`:
  - `must match existing teams integration external IDs` from the new `CompanyTeamExternalId` validator.
  - `mutually_exclusive` error when both id-keyed and extId-keyed team params are sent together.

## Why

Companion to LA-35266 (api-docs#38) which documented `integrationExternalId` on the Teams API. Third-party integrations shouldn't need the LA-internal `team.id` when provisioning users either.


[LA-35267]: https://learnamp.atlassian.net/browse/LA-35267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ