### PR TITLE
Fix communities scope name and warn about granular-scope token requests

### DIFF
--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -79,6 +79,10 @@ By default, tokens are issued with the `public` scope, which provides basic acce
 
 Legacy scopes are created with full access, and implicitly request and are granted the `public` scope. Moving forward, API credentials should be provisioned with the specific scopes they require.
 
+<aside class="warning">
+If your API credentials were provisioned with specific scopes only (no <code>public</code>), you <strong>must</strong> pass an explicit <code>scope</code> parameter in your token request. Omitting <code>scope</code> falls back to the default <code>public</code> scope, which your credentials do not allow, and the request will fail with <code>invalid_scope</code>.
+</aside>
+
 ### Available Scopes
 
 Scope | Description
@@ -106,7 +110,7 @@ users:update | Update existing users
 users:delete | Delete users
 users:deactivate | Deactivate users
 users:reactivate | Reactivate users
-communities:read | Read access to communities
+communities_posts:read | Read access to community posts
 tasks:read | Read access to tasks
 verbs:read | Read access to verbs
 languages:read | Read access to languages


### PR DESCRIPTION
## Summary

Two fixes to the Authentication section based on a live customer-integrator report and verification against the Doorkeeper config in \`learnamp/learnamp\`.

### 1. \`communities:read\` → \`communities_posts:read\`

The Available Scopes table listed \`communities:read\`, but that scope doesn't exist in \`config/initializers/doorkeeper.rb\`. The actual scope is \`communities_posts:read\` (registered in [LA-25893](https://learnamp.atlassian.net/browse/LA-25893)). Clients copying \`communities:read\` from the docs into their \`scope=\` param get rejected by Doorkeeper as an unknown scope. Already used correctly in \`_communities.md:51\`.

### 2. Warning for granular-scope token requests

The cURL example shows omitting \`scope=\`, which works fine for legacy / default credentials (Doorkeeper falls back to \`default_scopes :public\`, which the credential allows). But credentials provisioned with **granular scopes only** (no \`public\`) fail with HTTP 400 \`invalid_scope\` when \`scope=\` is omitted — the fallback to \`:public\` isn't allowed by the credential.

Verified locally:

| Test | Scenario | Result |
|---|---|---|
| 1 | Granular app (\`users:read items:read\`), no \`scope=\` param | HTTP 400 \`invalid_scope\` |
| 2 | Same granular app, \`scope=users:read\` explicit | HTTP 200, token issued with \`scope=users:read\` |
| 3 | Default/legacy app (\`scopes: public\`), no \`scope=\` param | HTTP 200, token issued with \`scope=public\` |

Added a \`<aside class="warning">\` after the "Moving forward, API credentials should be provisioned with the specific scopes they require." line explaining that callers must pass an explicit \`scope=\` for granular-only credentials.

## Why

Companies using the OAuth Applications UI to pick granular scopes (no \`public\`) hit this immediately, with no guidance from the docs about why their token request fails.

[LA-25893]: https://learnamp.atlassian.net/browse/LA-25893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to scope names and token-request guidance; no runtime or security code paths are modified.
> 
> **Overview**
> Updates the **Authentication** OAuth scopes documentation so it matches Doorkeeper and granular-credential behavior.
> 
> The Available Scopes table **replaces** the non-existent `communities:read` entry with **`communities_posts:read`**, aligning the public scope list with the app config and with `_communities.md`.
> 
> A new **warning** explains that credentials provisioned with **specific scopes only** (no `public`) must include an explicit `scope` on the token request; otherwise Doorkeeper defaults to `public` and returns **`invalid_scope`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7bc64577b4b456b04230a7133ed5705fc3cabd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->