### PR TITLE
Document new metadata fields on GET /v1/items list

### DIFF
--- a/source/includes/_items.md
+++ b/source/includes/_items.md
@@ -63,7 +63,13 @@ Response will be paginated [see pagination](#pagination)
             "shortDescription": null,
             "itemType": "Video",
             "itemCategory": "Audio/Visual",
-            "itemUrl": "https://examplecompany.learnamp.com/en/items/activity-10"
+            "itemUrl": "https://examplecompany.learnamp.com/en/items/activity-10",
+            "createdAt": "2021-03-02T11:09:35Z",
+            "updatedAt": "2021-03-02T12:24:02Z",
+            "addedBy": {
+                "id": 1
+            },
+            "tags": ["marketing", "video"]
         },
         {
             "id": 3014,
@@ -71,12 +77,20 @@ Response will be paginated [see pagination](#pagination)
             "shortDescription": null,
             "itemType": "Other",
             "itemCategory": "Other",
-            "itemUrl": "https://examplecompany.learnamp.com/en/items/rust-lang-rust"
+            "itemUrl": "https://examplecompany.learnamp.com/en/items/rust-lang-rust",
+            "createdAt": "2021-03-01T09:15:00Z",
+            "updatedAt": "2021-03-01T09:15:00Z",
+            "addedBy": {
+                "id": null
+            },
+            "tags": []
         }
     ]
 }
 
 ```
+
+Each item includes `createdAt`, `updatedAt`, `addedBy` and `tags`. `addedBy` contains only the user `id` who added the item. When an item was added by an external contributor, `addedBy.id` is `null` — the full contributor details are available on the [single item endpoint](#show-an-item).
 
 ## Show an Item
 


### PR DESCRIPTION
## Jira

[LA-36693](https://learnamp.atlassian.net/browse/LA-36693)

## What

Documents the new metadata fields added to the `GET /v1/items` list response in learnamp/learnamp#23571.

The "View all Items" response example now shows `createdAt`, `updatedAt`, `addedBy` (just `{ id }`) and `tags` on each item, with one item illustrating the external-contributor case where `addedBy.id` is `null`.

## Why

Before this change, customers had to call `GET /v1/items/:id` for every item just to read this metadata. The list endpoint now surfaces it directly, so the docs should reflect the richer list payload.

## Related

- Code PR: learnamp/learnamp#23571


[LA-36693]: https://learnamp.atlassian.net/browse/LA-36693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to an example JSON block and explanatory text; no runtime or API behavior in this repo.
> 
> **Overview**
> Updates the **View all Items** (`GET /v1/items`) docs so the list response example matches the richer API payload from the related code change.
> 
> Each item in the example JSON now includes **`createdAt`**, **`updatedAt`**, **`addedBy`** (object with only **`id`**), and **`tags`**. A second example item shows **`addedBy.id`: `null`** for externally contributed content.
> 
> New prose explains that list items expose this metadata without per-item calls, and that full contributor details remain on the [single item endpoint](#show-an-item) when **`addedBy.id`** is null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b71aabff9d39e21def530ab9d6e26ead47254fc9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->