### PR TITLE
Document GET /v1/learnlists/:id show endpoint

### DIFF
--- a/source/includes/_learnlists.md
+++ b/source/includes/_learnlists.md
@@ -62,10 +62,74 @@ Response will be paginated [see pagination](#pagination)
     "learnlists": [
         {
             "id": 379,
-            "title": "Test learnlist",
+            "name": "Test learnlist",
             "description": "This is the learnlist description"
         },
   ]
 }
 
+```
+
+## Show a Learnlist
+
+> Display details for a single Learnlist:
+
+```shell
+curl --location --request GET 'https://api.learnamp.com/v1/learnlists/379' \
+--header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
+```
+
+```ruby
+module Learnamp
+  class Learnlists
+    include HTTParty
+    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+
+    attr_accessor :token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def find(id)
+      response = self.class.get("/learnlists/#{id}", { headers: headers })
+      response.parsed_response
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{token}"
+      }
+    end
+  end
+end
+
+learnlist = Learnamp::Learnlists.new(token).find(379)
+```
+
+Display details for one specific Learnlist.
+
+`GET https://{API_BASE_URL}/v1/learnlists/{learnlistId}`
+
+### Required Scope
+This endpoint requires the `learnlists:read` scope.
+
+> 200 OK - successful response:
+
+```json
+{
+    "id": 379,
+    "name": "Test learnlist",
+    "description": "This is the learnlist description"
+}
+```
+
+> 404 Not Found - unsuccessful response:
+
+```json
+{
+    "error": "Not found"
+}
 ```


### PR DESCRIPTION
## Jira

[LA-36705](https://learnamp.atlassian.net/browse/LA-36705)

## What

Documents the new `GET /v1/learnlists/:id` show endpoint added in learnamp/learnamp#23579.

- Adds a **Show a Learnlist** section to the Learnlists docs (curl + Ruby examples, required scope, 200 and 404 responses), mirroring the existing **Show an Item** section.
- The response is presented with the existing `Learnlists::Simple` entity, returning `id`, `name` and `description`.

## Why

Until now only the collection route (`GET /v1/learnlists`) was documented; there was no docs entry for fetching a single learnlist by id.

## Anything Else

- Fixed a pre-existing inaccuracy in the **View All Learnlists** example: the field is `name`, not `title`. Verified against `Entities::Learnlists::Simple` (`expose :id, :name, :description`) — the same entity both routes use.
- Code PR: learnamp/learnamp#23579


[LA-36705]: https://learnamp.atlassian.net/browse/LA-36705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or security impact.
> 
> **Overview**
> Adds API docs for **`GET /v1/learnlists/{learnlistId}`**, including curl and Ruby `find` examples, the **`learnlists:read`** scope, and sample **200** (`id`, `name`, `description`) and **404** responses—aligned with the existing **Show an Item** pattern.
> 
> Corrects the **View All Learnlists** list example so each learnlist uses **`name`** instead of **`title`**, matching the documented simple entity shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5e147092b1cd55f684719e7bc84f845d520386e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->