### PR TITLE
Document GET /v1/learnlists/:id/contents sub-resource

### DIFF
--- a/source/includes/_learnlists.md
+++ b/source/includes/_learnlists.md
@@ -133,3 +133,107 @@ This endpoint requires the `learnlists:read` scope.
     "error": "Not found"
 }
 ```
+
+## List a Learnlist's Contents
+
+> List the contents of a single Learnlist:
+
+```shell
+curl --location --request GET 'https://api.learnamp.com/v1/learnlists/379/contents' \
+--header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
+```
+
+```ruby
+module Learnamp
+  class Learnlists
+    include HTTParty
+    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+
+    attr_accessor :token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def contents(id, filters = {})
+      filters_query = URI.encode_www_form(filters)
+      response = self.class.get("/learnlists/#{id}/contents?#{filters_query}", { headers: headers })
+      response.parsed_response
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{token}"
+      }
+    end
+  end
+end
+
+contents = Learnamp::Learnlists.new(token).contents(379)
+```
+
+List all of a Learnlist's contents, in Learnlist order.
+
+A Learnlist can contain more than just Items — it may also hold Quizzes, Surveys and Events. This endpoint returns every entry, regardless of type. Each entry carries a `type` discriminator (`Item`, `Quiz`, `Survey` or `Event`) which you can pair with the entry `id` to fetch type-specific detail from the relevant endpoint (e.g. `GET /v1/items/:id`).
+
+`GET https://{API_BASE_URL}/v1/learnlists/{learnlistId}/contents`
+
+### Required Scope
+This endpoint requires the `learnlists:read` scope.
+
+Response will be paginated [see pagination](#pagination)
+
+> 200 OK - successful response:
+
+```json
+{
+    "contents": [
+        {
+            "id": 1180,
+            "name": "Intro to Onboarding",
+            "shortDescription": "A short welcome video.",
+            "type": "Item",
+            "url": "https://examplecompany.learnamp.com/en/items/intro-to-onboarding",
+            "totalTimeEstimate": "< 5 mins",
+            "addedBy": {
+                "id": 1
+            }
+        },
+        {
+            "id": 477,
+            "name": "Onboarding Knowledge Check",
+            "shortDescription": "Assess what you've learned.",
+            "type": "Quiz",
+            "url": "https://examplecompany.learnamp.com/en/quizzes/477",
+            "totalTimeEstimate": "< 1 hr",
+            "addedBy": {
+                "id": 1
+            }
+        },
+        {
+            "id": 58,
+            "name": "Team Welcome Session",
+            "shortDescription": null,
+            "type": "Event",
+            "url": "https://examplecompany.learnamp.com/en/events/58",
+            "totalTimeEstimate": "1 hr",
+            "addedBy": {
+                "id": null
+            }
+        }
+    ]
+}
+
+```
+
+`addedBy` contains only the `id` of the user who added the entry. When the entry was added by an external contributor, `addedBy.id` is `null`. For content types that do not track who added them, `addedBy` is omitted entirely.
+
+> 404 Not Found - unsuccessful response:
+
+```json
+{
+    "error": "Not found"
+}
+```


### PR DESCRIPTION
## Jira

[LA-36706](https://learnamp.atlassian.net/browse/LA-36706)

## What

Documents the new `GET /v1/learnlists/:id/contents` sub-resource added in learnamp/learnamp#23581.

- Adds a **List a Learnlist's Contents** section to the Learnlists docs (curl + Ruby examples, required scope, paginated 200 response, 404 response).
- Explains that a learnlist is polymorphic: the listing returns Items, Quizzes, Surveys and Events, each carrying a `type` discriminator that pairs with the entry `id` to fetch type-specific detail.
- Documents the slimmed `addedBy` (`{ id }` only): `id` is `null` for external contributors, and `addedBy` is omitted for content types that don't track an adder.
- Notes the response is paginated, consistent with the other list endpoints.

## Why

The code PR exposes a learnlist's full contents for the first time; there was no docs entry for it. Fields documented were verified against the source entities (`Entities::Activityables::Simple` + the `Learnlists::Content` subclass).

## Anything Else

- Branched off latest `main`; independent of the in-flight learnlists-show docs PR. Both touch `_learnlists.md`, so a trivial rebase may be needed depending on merge order.
- Documented the granular `learnlists:read` scope to match the convention used by neighbouring sections; the route also accepts the `public` scope.
- Code PR: learnamp/learnamp#23581


[LA-36706]: https://learnamp.atlassian.net/browse/LA-36706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or API behavior impact.
> 
> **Overview**
> Adds **List a Learnlist's Contents** to `_learnlists.md`, documenting `GET /v1/learnlists/{learnlistId}/contents` with curl and Ruby samples, `learnlists:read` scope, pagination, and 200/404 examples.
> 
> The prose explains polymorphic entries (**Item**, **Quiz**, **Survey**, **Event**) via `type` + `id`, and documents the slim `addedBy` shape (`{ id }` only, `null` for external contributors, omitted when not tracked).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 647a1e83c128d27378e551e3381271b16cd35c42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->