### PR TITLE
Document new Cezanne language codes on User API

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -374,7 +374,7 @@ email | testuser@test.com | Email address of user *(\*)*
 firstName | Test | First name of user *(\*)*
 lastName | User | Last name of user *(\*)*
 integrationExternalId | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company.
-language | fr | Primary language short code. One of:  en (UK English), en-US (US English), de (German), es-CO (Colombian Spanish), fr (French), it (Italian), nl (Dutch), pt-BR (Brazilian Portuguese), pl (Polish), ru (Russian), zh-CN (Simplified Chinese), zh-TW (Traditional Chinese), ja (Japanese), ar (Arabic), cy (Welsh), el (Greek), hu (Hungarian), pt-PT (European Portuguese), ro (Romanian), tr (Turkish)
+language | fr | Primary language short code (e.g. `fr`). Must be one of the [supported language codes](#supported-language-codes).
 jobTitle | Developer | Job title of user
 role | viewer | user's role. One of: viewer, curator, admin, hr, reporter
 primaryTeamId | 15 | Team ID of primary team [see Teams](#teams)
@@ -591,7 +591,7 @@ email | email |testuser@test.com | Email address of user *(\*)*
 firstName | string | Test | First name of user *(\*)*
 lastName | string | User | Last name of user *(\*)*
 integrationExternalId | string | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company. Send `null` or `""` to clear an existing value.
-language | enum | fr | Primary language short code. One of:  en (UK English), en-US (US English), de (German), es-CO (Colombian Spanish), fr (French), it (Italian), nl (Dutch), pt-BR (Brazilian Portuguese), pl (Polish), ru (Russian), zh-CN (Simplified Chinese), zh-TW (Traditional Chinese), ja (Japanese), ar (Arabic), cy (Welsh), el (Greek), hu (Hungarian), pt-PT (European Portuguese), ro (Romanian), tr (Turkish)
+language | enum | fr | Primary language short code (e.g. `fr`). Must be one of the [supported language codes](#supported-language-codes).
 jobTitle | string |Developer | Job title of user
 primaryTeamId | integer | 15 | Team ID of primary team [see Teams](#teams)
 primaryTeamIntegrationExternalId | string | "EPOS-001" | Primary team's `integrationExternalId` [see Teams](#teams). Mutually exclusive with `primaryTeamId`.
@@ -1113,3 +1113,32 @@ Response will be paginated [see pagination](#pagination)
     "error": "Not found"
 }
 ```
+
+## Supported Language Codes
+
+The `language` field on the [Create](#create-a-user) and [Update](#update-a-user) user endpoints accepts one of the codes below.
+
+<aside class="notice">Send the <strong>code</strong> (the value in the left column, e.g. <code>fr</code>) — not the language name. The Language column is for reference only.</aside>
+
+Code | Language
+---- | --------
+`en` | UK English
+`en-US` | US English
+`de` | German
+`es-CO` | Colombian Spanish
+`fr` | French
+`it` | Italian
+`nl` | Dutch
+`pt-BR` | Brazilian Portuguese
+`pl` | Polish
+`ru` | Russian
+`zh-CN` | Simplified Chinese
+`zh-TW` | Traditional Chinese
+`ja` | Japanese
+`ar` | Arabic
+`cy` | Welsh
+`el` | Greek
+`hu` | Hungarian
+`pt-PT` | European Portuguese
+`ro` | Romanian
+`tr` | Turkish

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -374,7 +374,7 @@ email | testuser@test.com | Email address of user *(\*)*
 firstName | Test | First name of user *(\*)*
 lastName | User | Last name of user *(\*)*
 integrationExternalId | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company.
-language | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, it, nl, pt-BR, pl, ru, zh-CN, zh-TW, ja, ar, cy, el, hu, pt-PT, ro, tr
+language | fr | Primary language short code. One of:  en (UK English), en-US (US English), de (German), es-CO (Colombian Spanish), fr (French), it (Italian), nl (Dutch), pt-BR (Brazilian Portuguese), pl (Polish), ru (Russian), zh-CN (Simplified Chinese), zh-TW (Traditional Chinese), ja (Japanese), ar (Arabic), cy (Welsh), el (Greek), hu (Hungarian), pt-PT (European Portuguese), ro (Romanian), tr (Turkish)
 jobTitle | Developer | Job title of user
 role | viewer | user's role. One of: viewer, curator, admin, hr, reporter
 primaryTeamId | 15 | Team ID of primary team [see Teams](#teams)
@@ -591,7 +591,7 @@ email | email |testuser@test.com | Email address of user *(\*)*
 firstName | string | Test | First name of user *(\*)*
 lastName | string | User | Last name of user *(\*)*
 integrationExternalId | string | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company. Send `null` or `""` to clear an existing value.
-language | enum | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, it, nl, pt-BR, pl, ru, zh-CN, zh-TW, ja, ar, cy, el, hu, pt-PT, ro, tr
+language | enum | fr | Primary language short code. One of:  en (UK English), en-US (US English), de (German), es-CO (Colombian Spanish), fr (French), it (Italian), nl (Dutch), pt-BR (Brazilian Portuguese), pl (Polish), ru (Russian), zh-CN (Simplified Chinese), zh-TW (Traditional Chinese), ja (Japanese), ar (Arabic), cy (Welsh), el (Greek), hu (Hungarian), pt-PT (European Portuguese), ro (Romanian), tr (Turkish)
 jobTitle | string |Developer | Job title of user
 primaryTeamId | integer | 15 | Team ID of primary team [see Teams](#teams)
 primaryTeamIntegrationExternalId | string | "EPOS-001" | Primary team's `integrationExternalId` [see Teams](#teams). Mutually exclusive with `primaryTeamId`.

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -374,7 +374,7 @@ email | testuser@test.com | Email address of user *(\*)*
 firstName | Test | First name of user *(\*)*
 lastName | User | Last name of user *(\*)*
 integrationExternalId | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company.
-language | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, it, nl, pt-BR, pl, ru, zh-CN, zh-TW, ja, ar
+language | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, it, nl, pt-BR, pl, ru, zh-CN, zh-TW, ja, ar, cy, el, hu, pt-PT, ro, tr
 jobTitle | Developer | Job title of user
 role | viewer | user's role. One of: viewer, curator, admin, hr, reporter
 primaryTeamId | 15 | Team ID of primary team [see Teams](#teams)
@@ -591,7 +591,7 @@ email | email |testuser@test.com | Email address of user *(\*)*
 firstName | string | Test | First name of user *(\*)*
 lastName | string | User | Last name of user *(\*)*
 integrationExternalId | string | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company. Send `null` or `""` to clear an existing value.
-language | enum | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, it, nl, pt-BR, pl, ru, zh-CN, zh-TW, ja, ar
+language | enum | fr | Primary language short code. One of:  en, en-US, de, es-CO, fr, it, nl, pt-BR, pl, ru, zh-CN, zh-TW, ja, ar, cy, el, hu, pt-PT, ro, tr
 jobTitle | string |Developer | Job title of user
 primaryTeamId | integer | 15 | Team ID of primary team [see Teams](#teams)
 primaryTeamIntegrationExternalId | string | "EPOS-001" | Primary team's `integrationExternalId` [see Teams](#teams). Mutually exclusive with `primaryTeamId`.


### PR DESCRIPTION
## Jira

[LA-36685](https://learnamp.atlassian.net/browse/LA-36685)

## What

Documents the new language codes the User API now accepts, following learnamp/learnamp#23564.

That PR adds `cy, el, hu, pt-PT, ro, tr` to the app's `I18n.available_locales`. The User provisioning API validates the `language` parameter with `values: I18n.available_locales.map(&:to_s)`, so these codes are now valid `language` values. I've added them to the documented enum on both the **Create a user** and **Update a user** request tables in `_users.md`.

## Why

The `language` parameter doc enumerates the accepted short codes; without this, integrators have no way to know the six new locales are now valid.

## Anything Else

- Verified against the User API source: `optional :language, values: I18n.available_locales.map(&:to_s)` (both POST and PUT). The accepted set is exactly `I18n.available_locales`.
- **Out of scope, flagging for a decision:** the documented enum was *already* missing five locales that are in `I18n.available_locales` but predate this PR — `es, no, sv, da, sk`. I left those alone to keep this PR scoped to #23564. Happy to sync the full list (here or separately) if you'd like.
- There is also a `GET /v1/languages` endpoint (returns `I18n.available_locales` live) that isn't documented in api-docs at all — separate gap, not touched here.
- Code PR: learnamp/learnamp#23564


[LA-36685]: https://learnamp.atlassian.net/browse/LA-36685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to API reference markdown; no runtime or API behavior changes in this repo.
> 
> **Overview**
> User API docs in `_users.md` now document the expanded `language` values from the Cezanne locale work instead of an inline enum on create/update.
> 
> The **Create a user** and **Update a user** body tables no longer list every code in the parameter row; they point integrators to a new **Supported Language Codes** section. That section adds **`cy`, `el`, `hu`, `pt-PT`, `ro`, and `tr`** alongside the existing codes and clarifies that requests must send the short **code**, not the language name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b381f80fd6905d8b6ba61d9578dd483ba22b2d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->