### PR TITLE
Document displayType field on activities feed

### DIFF
--- a/source/includes/_activities.md
+++ b/source/includes/_activities.md
@@ -95,6 +95,7 @@ filters[verb] | "started" | Return activity for a specific verb. See [verbs](#ve
                 "name": "User Added Content",
                 "shortDescription": null,
                 "type": "Item",
+                "displayType": "Item",
                 "url": "https://examplecompany.learnamp.com/en/items/user-added-content",
                 "addedBy": {
                     "id": 7,
@@ -142,6 +143,9 @@ filters[verb] | "started" | Return activity for a specific verb. See [verbs](#ve
 }
 ```
 
+<aside class="notice">
+The <code>activityable</code> object exposes two type fields. <code>type</code> is the internal model name (e.g. <code>Item</code>, <code>Carousel</code>) and is a stable contract. <code>displayType</code> is the product-facing name shown in the Learn Amp UI — it matches <code>type</code> for every type <strong>except a Carousel, whose <code>displayType</code> is <code>Channel</code></strong>. When filtering by <code>filters[activityable_type]</code> (see below), use the display name <code>Channel</code>, not <code>Carousel</code>.
+</aside>
 
 > 200 OK - successful response:, with expanded=true param
 
@@ -155,6 +159,7 @@ filters[verb] | "started" | Return activity for a specific verb. See [verbs](#ve
                 "name": "Marketing 101",
                 "shortDescription": null,
                 "type": "Item",
+                "displayType": "Item",
                 "url": "https://examplecompany.learnamp.com/en/items/dani",
                 "addedBy": {
                     "id": 1,


### PR DESCRIPTION
## Jira

[LA-36764](https://learnamp.atlassian.net/browse/LA-36764) (sub-task of [LA-36512](https://learnamp.atlassian.net/browse/LA-36512))

## What

Documents the new additive `displayType` field on the `activityable` object, added in learnamp/learnamp#23613.

- Adds `displayType` to both response examples (default and `expanded=true`) on **View All Activity**.
- Adds a note explaining the distinction: `type` is the internal model name (stable contract); `displayType` is the product-facing UI name. They match for everything **except a Carousel, whose `displayType` is `Channel`**.
- Ties it to the existing `filters[activityable_type]` input, which already uses the display name `Channel` — clearing up the long-standing mismatch where you filter by `Channel` but `type` comes back `Carousel`.

## Why

The code PR exposes `displayType` so API consumers get the product-facing "Channel" label without a breaking change to `type`. The docs should explain both fields and the Carousel/Channel special case.

## Anything Else

- `displayType` lives on the shared `Activityables::Simple` entity, so it also appears on `GET /v1/learnlists/:id/contents`. That endpoint's docs are in the **still-unmerged PR #46** (off a different branch), so I documented `displayType` only on the activities feed here. Once #46 merges, the `/contents` example should get `displayType` too — happy to follow up on whichever branch lands first.
- Branched off latest `main`; independent of PRs #44–#47.
- Code PR: learnamp/learnamp#23613


[LA-36764]: https://learnamp.atlassian.net/browse/LA-36764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LA-36512]: https://learnamp.atlassian.net/browse/LA-36512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates to API examples and a clarifying notice; no runtime or security impact.
> 
> **Overview**
> Documents the additive **`displayType`** field on **`activityable`** in the **View All Activity** (`GET /v1/activities`) examples for both default and **`expanded=true`** responses.
> 
> A notice clarifies that **`type`** stays the internal/stable model name while **`displayType`** is the UI-facing label (same except **Carousel** → **Channel**), and that **`filters[activityable_type]`** should use **`Channel`**, not **`Carousel`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec5b08522c02951e0d54e34a974807ebc7971825. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->