### PR TITLE
Document GET /v1/items/:id/learnlists sub-resource

### DIFF
--- a/source/includes/_items.md
+++ b/source/includes/_items.md
@@ -187,6 +187,78 @@ This endpoint requires the `items:read` scope.
 }
 ```
 
+## List Learnlists Containing an Item
+
+> List the learnlists that contain a single item:
+
+```shell
+curl --location --request GET 'https://api.learnamp.com/v1/items/3015/learnlists' \
+--header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
+```
+
+```ruby
+module Learnamp
+  class Items
+    include HTTParty
+    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+
+    attr_accessor :token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def learnlists(id, filters = {})
+      filters_query = URI.encode_www_form(filters)
+      response = self.class.get("/items/#{id}/learnlists?#{filters_query}", { headers: headers })
+      response.parsed_response
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{token}"
+      }
+    end
+  end
+end
+
+learnlists = Learnamp::Items.new(token).learnlists(3015)
+```
+
+List all of the learnlists that contain a given item, most recently created first.
+
+`GET https://{API_BASE_URL}/v1/items/{itemId}/learnlists`
+
+### Required Scope
+This endpoint requires the `items:read` scope.
+
+Response will be paginated [see pagination](#pagination)
+
+> 200 OK - successful response:
+
+```json
+{
+    "learnlists": [
+        {
+            "id": 379,
+            "name": "Test learnlist",
+            "description": "This is the learnlist description"
+        }
+    ]
+}
+
+```
+
+> 404 Not Found - unsuccessful response:
+
+```json
+{
+    "error": "Not found"
+}
+```
+
 ## Create an Item
 
 > Create a new Item:


### PR DESCRIPTION
## Jira

[LA-36512](https://learnamp.atlassian.net/browse/LA-36512)

## What

Documents the new `GET /v1/items/:id/learnlists` sub-resource added in learnamp/learnamp#23612.

- Adds a **List Learnlists Containing an Item** section to the Items docs (curl + Ruby examples, required scope, paginated 200 response, 404 response), mirroring the **Show an Item** style.
- Returns the learnlists that contain the item, most recently created first, presented with the existing `Learnlists::Simple` entity (`id`, `name`, `description`).

## Why

AC #3 of LA-36512: surface the learnlists an item belongs to directly, so consumers don't have to reverse-engineer membership from the learnlists index.

## Anything Else

- This is the items-side mirror of `GET /v1/learnlists/:id/contents` (PR #46). Response shape verified against `Entities::Learnlists::Simple` (`expose :id, :name, :description`) — note the field is `name`, consistent with PRs #45/#46.
- Documented the granular `items:read` scope to match the convention used by neighbouring sections; the route also accepts the `public` scope.
- Branched off latest `main`; independent of PRs #44–#48.
- Code PR: learnamp/learnamp#23612


[LA-36512]: https://learnamp.atlassian.net/browse/LA-36512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to API reference markdown; no runtime or security impact.
> 
> **Overview**
> Adds API documentation for **`GET /v1/items/{itemId}/learnlists`**, placed after **Show an Item** and before **Create an Item**.
> 
> The new **List Learnlists Containing an Item** section documents how to list learnlists that include a given item (newest first), with curl and Ruby (`Learnamp::Items#learnlists`) examples, **`items:read`** scope, pagination, a 200 payload of simple learnlist objects (`id`, `name`, `description`), and a 404 error shape—aligned with neighbouring Items sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de0dc6b7d020e7538d592ebf4718c788547032d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->