### PR TITLE
[LA-36706] Document displayType on learnlist contents

### DIFF
--- a/source/includes/_learnlists.md
+++ b/source/includes/_learnlists.md
@@ -178,6 +178,8 @@ List all of a Learnlist's contents, in Learnlist order.
 
 A Learnlist can contain more than just Items — it may also hold Quizzes, Surveys and Events. This endpoint returns every entry, regardless of type. Each entry carries a `type` discriminator (`Item`, `Quiz`, `Survey` or `Event`) which you can pair with the entry `id` to fetch type-specific detail from the relevant endpoint (e.g. `GET /v1/items/:id`).
 
+`displayType` is the product-facing label for the entry type. For Learnlist contents it always mirrors `type`; it differs only for content types whose internal name differs from the name shown in the product.
+
 `GET https://{API_BASE_URL}/v1/learnlists/{learnlistId}/contents`
 
 ### Required Scope
@@ -195,6 +197,7 @@ Response will be paginated [see pagination](#pagination)
             "name": "Intro to Onboarding",
             "shortDescription": "A short welcome video.",
             "type": "Item",
+            "displayType": "Item",
             "url": "https://examplecompany.learnamp.com/en/items/intro-to-onboarding",
             "totalTimeEstimate": "< 5 mins",
             "addedBy": {
@@ -206,6 +209,7 @@ Response will be paginated [see pagination](#pagination)
             "name": "Onboarding Knowledge Check",
             "shortDescription": "Assess what you've learned.",
             "type": "Quiz",
+            "displayType": "Quiz",
             "url": "https://examplecompany.learnamp.com/en/quizzes/477",
             "totalTimeEstimate": "< 1 hr",
             "addedBy": {
@@ -217,6 +221,7 @@ Response will be paginated [see pagination](#pagination)
             "name": "Team Welcome Session",
             "shortDescription": null,
             "type": "Event",
+            "displayType": "Event",
             "url": "https://examplecompany.learnamp.com/en/events/58",
             "totalTimeEstimate": "1 hr",
             "addedBy": {


### PR DESCRIPTION
## Jira

[LA-36706](https://learnamp.atlassian.net/browse/LA-36706)

## What

Follow-up to #46 (merged). Documents the `displayType` field on the `GET /v1/learnlists/:id/contents` response, which #46's example omitted.

The `/contents` entity (`Learnlists::Content`) inherits from the shared `Activityables::Simple`, which exposes `display_type` — so every contents entry returns `displayType` alongside `type`. The field was added to that shared entity by the Carousel→Channel work (code PR learnamp/learnamp#23613) and is already documented for the activities feed in #48, but not for learnlist contents.

- Adds `displayType` to each entry in the `/contents` 200 example.
- Adds a one-line note: for learnlist contents `displayType` always mirrors `type` (contents are only Item/Quiz/Survey/Event, never Carousel); it diverges only where the internal type name differs from the product-facing label.

## Why

Docs-accuracy: the live endpoint returns `displayType`, so the documented example should include it. Redundant for this endpoint, but present in the payload.


[LA-36706]: https://learnamp.atlassian.net/browse/LA-36706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to example payloads and prose; no runtime or API behavior changes.
> 
> **Overview**
> Documents **`displayType`** on **`GET /v1/learnlists/{learnlistId}/contents`** so the published example matches the live API (field comes from the shared `Activityables::Simple` serializer).
> 
> Adds a short note that for learnlist contents **`displayType`** always matches **`type`** (Item/Quiz/Survey/Event only), and only diverges where internal type names differ from product-facing labels—aligned with how activities docs already describe the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69fe31ae2e40f761d2dc1c67d196c5d48110113. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->