### PR TITLE
[LA-36814] Doc status filter + item channels endpoints

### DIFF
--- a/source/includes/_items.md
+++ b/source/includes/_items.md
@@ -273,6 +273,77 @@ Response will be paginated [see pagination](#pagination)
 }
 ```
 
+## List Channels Containing an Item
+
+> List the channels that contain a single item:
+
+```shell
+curl --location --request GET 'https://api.learnamp.com/v1/items/3015/channels' \
+--header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
+```
+
+```ruby
+module Learnamp
+  class Items
+    include HTTParty
+    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+
+    attr_accessor :token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def channels(id, filters = {})
+      filters_query = URI.encode_www_form(filters)
+      response = self.class.get("/items/#{id}/channels?#{filters_query}", { headers: headers })
+      response.parsed_response
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{token}"
+      }
+    end
+  end
+end
+
+channels = Learnamp::Items.new(token).channels(3015)
+```
+
+List all of the channels that contain a given item, most recently created first.
+
+`GET https://{API_BASE_URL}/v1/items/{itemId}/channels`
+
+### Required Scope
+This endpoint requires the `items:read` scope.
+
+Response will be paginated [see pagination](#pagination)
+
+> 200 OK - successful response:
+
+```json
+{
+    "channels": [
+        {
+            "id": 42,
+            "title": "Onboarding"
+        }
+    ]
+}
+
+```
+
+> 404 Not Found - unsuccessful response:
+
+```json
+{
+    "error": "Not found"
+}
+```
+
 ## Create an Item
 
 > Create a new Item:

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -69,6 +69,7 @@ filters[last_name] | Smith | Return users with matching last name (using `ILIKE 
 filters[role] | viewer | Return users with matching role. <br />Possible values: "viewer", "curator", "reporter", "hr", "admin", "owner"
 filters[no_team] | true | Return users that have no team assigned
 filters[team_ids] | *[1,2,3]* or *1,2,3* | Return members of any of the given teams by team ID.<br /><br />Param can be array of team ids, or a string of comma seperated team ids
+filters[status][] | confirmed | Return users matching any of the given statuses. Repeat the param to pass multiple, e.g. `filters[status][]=confirmed&filters[status][]=deactivated`.<br /><br />Possible values: "not_invited", "invite_scheduled", "invite_pending", "confirmed", "deactivated"
 filters[created_at][from] | "2021-12-31" | Created date range FROM date in ISO 8601 format
 filters[created_at][to] | "2022-02-28" | Created date range TO date in ISO 8601 format
 filters[updated_at][from] | "2021-12-31" | Updated date range FROM date in ISO 8601 format


### PR DESCRIPTION
### Jira
https://learnamp.atlassian.net/browse/LA-36814

### What
Documents two parts of the public API that already exist in code but were missing from the docs:

- **`GET /v1/items/:id/channels`** — new "List Channels Containing an Item" section in `_items.md`, mirroring the existing "List Learnlists Containing an Item". Returns the channels (Carousels) containing an item; response is `{ "channels": [{ "id", "title" }] }`, paginated, `items:read` scope.
- **`filters[status]`** on `GET /v1/users` — new row in the View All Users filter table in `_users.md`. Multi-value; possible values: not_invited, invite_scheduled, invite_pending, confirmed, deactivated.

### Why
Part of LA-36515 (Filter parity on list APIs). Customers (Namecheap, Winc Academy) need these documented to use them. The `/items/:id/channels` endpoint (LA-36812) and the `status` filter (LA-36813) are delivered in sibling learnamp PRs #23667 and #23668. `filters[no_team]` and `/items/:id/learnlists` were already documented, so they're untouched here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only API documentation; no runtime or security behavior changes.
> 
> **Overview**
> Documents two public API capabilities that already ship in the product but were missing from the docs.
> 
> **Items:** Adds a **List Channels Containing an Item** section for `GET /v1/items/{itemId}/channels`, aligned with the existing learnlists section—curl/Ruby examples, `items:read` scope, pagination, and a `{ "channels": [{ "id", "title" }] }` response plus 404.
> 
> **Users:** Adds **`filters[status][]`** to the View All Users filter table so callers can filter by one or more statuses (`not_invited`, `invite_scheduled`, `invite_pending`, `confirmed`, `deactivated`) via repeated query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4bfbfddf930cf35ff15f8884d96d2479ff9d339. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->