### PR TITLE
[LA-36685] Document missing supported language codes

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -1125,6 +1125,7 @@ Code | Language
 `en` | UK English
 `en-US` | US English
 `de` | German
+`es` | Spanish
 `es-CO` | Colombian Spanish
 `fr` | French
 `it` | Italian
@@ -1132,10 +1133,14 @@ Code | Language
 `pt-BR` | Brazilian Portuguese
 `pl` | Polish
 `ru` | Russian
+`no` | Norwegian
+`sv` | Swedish
+`da` | Danish
 `zh-CN` | Simplified Chinese
 `zh-TW` | Traditional Chinese
 `ja` | Japanese
 `ar` | Arabic
+`sk` | Slovak
 `cy` | Welsh
 `el` | Greek
 `hu` | Hungarian


### PR DESCRIPTION
## Jira
[LA-36685](https://learnamp.atlassian.net/browse/LA-36685)

## What
Adds five locales that the public API already accepts on the \`language\` field but were missing from the **Supported Language Codes** table in \`_users.md\`:

| Code | Language |
|------|----------|
| \`es\` | Spanish |
| \`no\` | Norwegian |
| \`sv\` | Swedish |
| \`da\` | Danish |
| \`sk\` | Slovak |

Each is inserted in its existing position in \`I18n.available_locales\` (\`config/initializers/1_locale.rb\`), so the documented table now matches the app's locale whitelist exactly (25 codes).

## Why
The table claims to be the authoritative list of values the \`language\` field accepts on the Create/Update User endpoints, but these five are fully-translated, first-class locales in the app — they were simply overlooked (note \`es-CO\` Colombian Spanish was listed while plain \`es\` was not). Customers integrating against the API had no documented way to know \`es\`/\`no\`/\`sv\`/\`da\`/\`sk\` were valid.

Follows on from the Cezanne locale work (LA-36685): it covers the Danish (\`da-DK\` → \`da\`) and Norwegian Bokmål (\`nb-NO\` → \`no\`) cases from the recent locale request; Hungarian (\`hu\`) and Polish (\`pl\`) were already documented. Catalan (\`ca-ES\`) is intentionally **not** added — the app has no Catalan locale, so that needs platform work, not a docs change.

## Screenshots
n/a — Markdown table change only.



[LA-36685]: https://learnamp.atlassian.net/browse/LA-36685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only documentation update with no runtime or API changes.
> 
> **Overview**
> Updates the **Supported Language Codes** table in `_users.md` so it lists five locales the Create/Update User `language` field already accepts but were omitted from the docs: `es`, `no`, `sv`, `da`, and `sk`. Rows are placed in the same order as the app’s locale list so the table matches the full set of valid codes (25 total).
> 
> No API or validation behavior changes—documentation only for integrators who rely on this table as the authoritative list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec8c589db19b3ce7e4b561a3294a68f79935ce23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->