### PR TITLE
Document status filter on GET /v1/users

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -67,6 +67,7 @@ filters[email] | email@test.com | Return users with matching email address
 filters[first_name] | John | Return users with matching first name (using `ILIKE '%value%'`)
 filters[last_name] | Smith | Return users with matching last name (using `ILIKE '%value%'`)
 filters[role] | viewer | Return users with matching role. <br />Possible values: "viewer", "curator", "reporter", "hr", "admin", "owner"
+filters[status] | *[confirmed,invite_pending]* or *confirmed* | Return users matching any of the given statuses.<br /><br />Param can be an array of statuses, or a string of comma separated statuses.<br />Possible values: "not_invited", "invite_scheduled", "invite_pending", "confirmed", "deactivated"
 filters[no_team] | true | Return users that have no team assigned
 filters[team_ids] | *[1,2,3]* or *1,2,3* | Return members of any of the given teams by team ID.<br /><br />Param can be array of team ids, or a string of comma seperated team ids
 filters[created_at][from] | "2021-12-31" | Created date range FROM date in ISO 8601 format


### PR DESCRIPTION
## Jira

[LA-36813](https://learnamp.atlassian.net/browse/LA-36813)

## What

Documents the new `filters[status]` query param on `GET /v1/users`, shipped by code PR learnamp/learnamp#23668 (merged). The endpoint reference was missing it.

Adds one row to the "Optional Filters in URL Params" table:

- Accepts an array of statuses, or a comma-separated string (same shape as `filters[team_ids]`).
- Matches users in **any** of the given statuses.
- Allow-list (verified against `APIServices::Filters::Users::VALID_STATUSES` and the Grape param): `not_invited`, `invite_scheduled`, `invite_pending`, `confirmed`, `deactivated`.

## Why

Docs-accuracy: the live endpoint accepts the filter, but the reference didn't list it.


[LA-36813]: https://learnamp.atlassian.net/browse/LA-36813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in `_users.md`; no runtime or API behavior is modified.
> 
> **Overview**
> Documents **`filters[status]`** on **`GET /v1/users`**, aligning the reference with behavior already shipped in the API.
> 
> The new table row describes filtering users who match **any** of the supplied statuses, using either an array or comma-separated values (same pattern as **`filters[team_ids]`**). Allowed values are **`not_invited`**, **`invite_scheduled`**, **`invite_pending`**, **`confirmed`**, and **`deactivated`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 798d673bb9bc4001c464946dc582f85d75a1a1d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->