### PR TITLE
[LA-36925] Document customField clear + occupationRole

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -617,6 +617,7 @@ Within the `customFields` array each entry is a `{ "name": ..., "value": ... }` 
 * **Omitting** a field from the `customFields` array leaves that field **unchanged** — omission does **not** clear it.
 * A custom field with **presence validation enabled cannot be cleared**: attempting to clear it returns `400 Bad Request` with a validation error and the existing value is retained.
 * An unknown custom field `name` returns `404 Not Found`.
+* If your company has custom fields disabled, the entire `customFields` payload is silently ignored and the rest of the update still succeeds.
 
 > 200 OK - successful response:
 

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -230,7 +230,7 @@ This endpoint requires the `users:read` scope.
     "language": "en",
     "role": "viewer",
     "integrationExternalId": "EPOS-12345",
-    "skillsMatrixRole": "Software Engineer",
+    "occupationRole": "Software Engineer",
     "hireDate": "2021-01-15",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1",
     "status": {
@@ -403,7 +403,7 @@ customFields | [{ name: "Employee ID", value: "12-34-56" }] | CustomFields param
     "language": "en",
     "role": "viewer",
     "integrationExternalId": "EPOS-12345",
-    "skillsMatrixRole": "Software Engineer",
+    "occupationRole": "Software Engineer",
     "hireDate": "2021-01-15",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1",
     "status": {
@@ -572,7 +572,7 @@ params = {
   hireDate:  "2021-02-28",
   location:  "London",
   department:  "Marketing",
-  skillsMatrixRole: "Software Engineer",
+  occupationRole: "Software Engineer",
   customFields: [{ name: "Employee ID", value: "123456" }]
 }
 
@@ -606,7 +606,7 @@ hireDate | date | 2021-02-28 | Employment start date for user in ISO 8601 date f
 location | string | London | Primary location of user
 department | string | Marketing | Department of user
 reactivate | boolean | true | Reactivates user if deactivated
-skillsMatrixRole | string | "Software Engineer" | Name of a skills-matrix role (an "occupation"/role defined in your company) to assign to the user. Assigns it as the user's primary role and applies the role's target skills, removing the need for the user to self-select a role during onboarding. An unknown role name returns `422 Unprocessable Entity`. Returned on the user object as `skillsMatrixRole`.
+occupationRole | string | "Software Engineer" | Name of a skills-matrix role (an "occupation"/role defined in your company) to assign to the user. Assigns it as the user's primary role and applies the role's target skills, removing the need for the user to self-select a role during onboarding. An unknown role name returns `422 Unprocessable Entity`. Returned on the user object as `occupationRole`.
 customFields | object | [{ name: "Employee ID", value: "12-34-56" }] | CustomFields param is an array, of name/value pairs for custom fields. See [Clearing custom field values](#clearing-custom-field-values) below.
 
 ### Clearing custom field values
@@ -631,7 +631,7 @@ Within the `customFields` array each entry is a `{ "name": ..., "value": ... }` 
     "language": "en",
     "role": "admin",
     "integrationExternalId": "EPOS-13820",
-    "skillsMatrixRole": "Software Engineer",
+    "occupationRole": "Software Engineer",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1382",
     "status": {
         "status": "Invite pending",
@@ -748,7 +748,7 @@ Within the `customFields` array each entry is a `{ "name": ..., "value": ... }` 
 }
 ```
 
-> 422 Unprocessable Entity - unknown `skillsMatrixRole` name:
+> 422 Unprocessable Entity - unknown `occupationRole` name:
 
 ```json
 {
@@ -823,7 +823,7 @@ Accepts the same body parameters as [Update a User](#update-a-user), including `
 * Lookup is scoped to your company — an unknown `integrationExternalId` returns `404 Not Found`.
 * Renaming to an `integrationExternalId` already used by another user in your company returns `400 Bad Request`.
 * Purely numeric values (e.g. `"42"`) are reachable through this subroute regardless of any user's `id`.
-* `customFields` clearing and `skillsMatrixRole` behave exactly as on [Update a User](#update-a-user) — see [Clearing custom field values](#clearing-custom-field-values).
+* `customFields` clearing and `occupationRole` behave exactly as on [Update a User](#update-a-user) — see [Clearing custom field values](#clearing-custom-field-values).
 
 > 200 OK - successful response:
 
@@ -838,7 +838,7 @@ Accepts the same body parameters as [Update a User](#update-a-user), including `
     "language": "en",
     "role": "admin",
     "integrationExternalId": "EPOS-12345",
-    "skillsMatrixRole": "Software Engineer",
+    "occupationRole": "Software Engineer",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1382",
     "status": {
         "status": "Confirmed",

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -752,7 +752,7 @@ Within the `customFields` array each entry is a `{ "name": ..., "value": ... }` 
 
 ```json
 {
-    "error": "Skills matrix role not found"
+    "error": "occupationRole does not match an existing role in your company"
 }
 ```
 

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -230,6 +230,7 @@ This endpoint requires the `users:read` scope.
     "language": "en",
     "role": "viewer",
     "integrationExternalId": "EPOS-12345",
+    "skillsMatrixRole": "Software Engineer",
     "hireDate": "2021-01-15",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1",
     "status": {
@@ -402,6 +403,7 @@ customFields | [{ name: "Employee ID", value: "12-34-56" }] | CustomFields param
     "language": "en",
     "role": "viewer",
     "integrationExternalId": "EPOS-12345",
+    "skillsMatrixRole": "Software Engineer",
     "hireDate": "2021-01-15",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1",
     "status": {
@@ -570,6 +572,7 @@ params = {
   hireDate:  "2021-02-28",
   location:  "London",
   department:  "Marketing",
+  skillsMatrixRole: "Software Engineer",
   customFields: [{ name: "Employee ID", value: "123456" }]
 }
 
@@ -603,7 +606,17 @@ hireDate | date | 2021-02-28 | Employment start date for user in ISO 8601 date f
 location | string | London | Primary location of user
 department | string | Marketing | Department of user
 reactivate | boolean | true | Reactivates user if deactivated
-customFields | object | [{ name: "Employee ID", value: "12-34-56" }] | CustomFields param is an array, of name/value pairs for custom fields.
+skillsMatrixRole | string | "Software Engineer" | Name of a skills-matrix role (an "occupation"/role defined in your company) to assign to the user. Assigns it as the user's primary role and applies the role's target skills, removing the need for the user to self-select a role during onboarding. An unknown role name returns `422 Unprocessable Entity`. Returned on the user object as `skillsMatrixRole`.
+customFields | object | [{ name: "Employee ID", value: "12-34-56" }] | CustomFields param is an array, of name/value pairs for custom fields. See [Clearing custom field values](#clearing-custom-field-values) below.
+
+### Clearing custom field values
+
+Within the `customFields` array each entry is a `{ "name": ..., "value": ... }` pair, matched by `name`:
+
+* To **clear** a custom field, send it with `"value": null` or `"value": ""` — the stored value is removed.
+* **Omitting** a field from the `customFields` array leaves that field **unchanged** — omission does **not** clear it.
+* A custom field with **presence validation enabled cannot be cleared**: attempting to clear it returns `400 Bad Request` with a validation error and the existing value is retained.
+* An unknown custom field `name` returns `404 Not Found`.
 
 > 200 OK - successful response:
 
@@ -618,6 +631,7 @@ customFields | object | [{ name: "Employee ID", value: "12-34-56" }] | CustomFie
     "language": "en",
     "role": "admin",
     "integrationExternalId": "EPOS-13820",
+    "skillsMatrixRole": "Software Engineer",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1382",
     "status": {
         "status": "Invite pending",
@@ -713,6 +727,35 @@ customFields | object | [{ name: "Employee ID", value: "12-34-56" }] | CustomFie
 }
 ```
 
+> 400 Bad request - clearing a custom field that has presence validation enabled (the existing value is retained):
+
+```json
+{
+    "error": "Validation failed: Value can't be blank",
+    "fullErrors": {
+        "value": [
+            "can't be blank"
+        ]
+    }
+}
+```
+
+> 404 Not Found - unknown custom field `name`:
+
+```json
+{
+    "error": "Not found"
+}
+```
+
+> 422 Unprocessable Entity - unknown `skillsMatrixRole` name:
+
+```json
+{
+    "error": "Skills matrix role not found"
+}
+```
+
 A user may also be updated by `integrationExternalId` via a dedicated subroute — see [Update a User by Integration External ID](#update-a-user-by-integration-external-id).
 
 ## Update a User by Integration External ID
@@ -780,6 +823,7 @@ Accepts the same body parameters as [Update a User](#update-a-user), including `
 * Lookup is scoped to your company — an unknown `integrationExternalId` returns `404 Not Found`.
 * Renaming to an `integrationExternalId` already used by another user in your company returns `400 Bad Request`.
 * Purely numeric values (e.g. `"42"`) are reachable through this subroute regardless of any user's `id`.
+* `customFields` clearing and `skillsMatrixRole` behave exactly as on [Update a User](#update-a-user) — see [Clearing custom field values](#clearing-custom-field-values).
 
 > 200 OK - successful response:
 
@@ -794,6 +838,7 @@ Accepts the same body parameters as [Update a User](#update-a-user), including `
     "language": "en",
     "role": "admin",
     "integrationExternalId": "EPOS-12345",
+    "skillsMatrixRole": "Software Engineer",
     "profileUrl": "https://testaccount.learnamp.com/en/users/1382",
     "status": {
         "status": "Confirmed",


### PR DESCRIPTION
## Jira

https://learnamp.atlassian.net/browse/LA-36925

## What

Documents two verified behaviours on the user-update API (`PUT /v1/users/:id` and the `by_integration_external_id` variant) in `source/includes/_users.md`:

1. **Clearing a customField value** — send `"value": null` or `"value": ""` to clear a field; omitting a field leaves it unchanged; clearing a presence-validated field returns `400 Bad Request` (value retained); an unknown field `name` returns `404 Not Found`.
2. **`occupationRole`** — new optional string attribute. Assigns an occupation role as the user's primary role and applies its target skills. Unknown role name returns `422 Unprocessable Entity`. Returned on the user object and readable back via `GET /v1/users/:id`.

## Why

Integrators need accurate docs for these shipped behaviours (customField clearing and occupation-role assignment).

## Anything Else

Docs-only change. No build run (Slate/Middleman site; build requires the full gem bundle and is not quick).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to Slate API reference; no runtime or API behavior changes in this PR.
> 
> **Overview**
> Updates the Users API docs in `_users.md` for **user update** flows (`PUT /v1/users/{id}` and **by integration external ID**).
> 
> Documents optional **`occupationRole`**: skills-matrix role name on update, returned on user JSON in show/create/update examples, with **`422`** when the name does not exist in the company.
> 
> Adds a **Clearing custom field values** section: clear via `null` or `""`, omission leaves values unchanged, presence-validated fields cannot be cleared (**`400`**), unknown field names **`404`**, and `customFields` ignored when the feature is disabled. Links the `customFields` parameter to that section and adds matching error response examples.
> 
> Notes that the integration-external-id update route follows the same **`customFields`** / **`occupationRole`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8941a953cb96759a5d2be1e9e87765fb88cd812a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->