### PR TITLE
[LA-36992] Document role param on user-update API docs

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -379,7 +379,7 @@ lastName | User | Last name of user *(\*)*
 integrationExternalId | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company.
 language | fr | Primary language short code (e.g. `fr`). Must be one of the [supported language codes](#supported-language-codes).
 jobTitle | Developer | Job title of user
-role | viewer | user's role. One of: viewer, curator, admin, hr, reporter
+role | viewer | user's role. One of: viewer, curator, reporter, learning_designer, hr, admin
 primaryTeamId | 15 | Team ID of primary team [see Teams](#teams)
 primaryTeamIntegrationExternalId | "EPOS-001" | Primary team's `integrationExternalId` [see Teams](#teams). Mutually exclusive with `primaryTeamId`.
 secondaryTeamIds | [376,377] | Array of Team IDs of seconary teams
@@ -598,6 +598,7 @@ lastName | string | User | Last name of user *(\*)*
 integrationExternalId | string | "EPOS-12345" | Optional third-party identifier for the user. Must be unique within your company. Send `null` or `""` to clear an existing value.
 language | enum | fr | Primary language short code (e.g. `fr`). Must be one of the [supported language codes](#supported-language-codes).
 jobTitle | string |Developer | Job title of user
+role | enum | admin | User's system role. One of: viewer, curator, reporter, learning_designer, hr, admin. `owner` and `super_admin` cannot be set via the API. `hr` requires the HR-role package on your company (otherwise returns `422 Unprocessable Entity`).
 primaryTeamId | integer | 15 | Team ID of primary team [see Teams](#teams)
 primaryTeamIntegrationExternalId | string | "EPOS-001" | Primary team's `integrationExternalId` [see Teams](#teams). Mutually exclusive with `primaryTeamId`.
 secondaryTeamIds | Array(integer) | [376,377] | Array of Team IDs of seconary teams


### PR DESCRIPTION
## Jira

https://learnamp.atlassian.net/browse/LA-36992

## What

Adds the `role` parameter to the **Update a User** "Data in Body" table, and corrects the role values listed on **Create a User** (was missing `learning_designer`).

## Why

The update endpoints (`PUT /v1/users/{userId}` and `PUT /v1/users/by_integration_external_id/{integrationExternalId}`) both accept `role` (`User.admin_settable_roles`), and the worked example plus the 200 response in the same docs section already show it, but the parameter table omitted it. The docs were internally inconsistent and hid a supported field from integrators.

The `by_integration_external_id` section cross-references "the same body parameters as Update a User", so it inherits the new row automatically.

## Acceptance Criteria

- [x] `role` documented in the Update a User parameter table
- [x] Allowed values listed accurately (viewer, curator, reporter, learning_designer, hr, admin; `owner`/`super_admin` excluded; `hr` package note)
- [x] Create a User role list corrected to include `learning_designer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only API documentation changes with no runtime or security impact.
> 
> **Overview**
> Updates **Users** API reference in `_users.md` so `role` is documented consistently for create and update.
> 
> **Create a User** — the `role` row now lists allowed values as `viewer`, `curator`, `reporter`, `learning_designer`, `hr`, `admin` (adds **`learning_designer`** and aligns ordering with the API).
> 
> **Update a User** — adds a **`role`** body parameter (`enum`, example `admin`) describing settable system roles, noting that `owner` and `super_admin` cannot be set via the API and that `hr` requires the HR-role package (otherwise `422`). The **by_integration_external_id** update path already defers to this table, so it picks up the new row without further edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2e89bbce5f89b65c9190305b8de2d823e6b1fac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->