### PR TITLE
[LA-36971] Document DELETE /v1/tasks/:id endpoint

### DIFF
--- a/source/includes/_tasks.md
+++ b/source/includes/_tasks.md
@@ -280,3 +280,64 @@ filters[lifecycle] | "active,deleted,deactivated" | Lifecycle status of task. Ca
     ]
 }
 ```
+## Delete a Task
+
+> Delete a task:
+
+```shell
+curl --location --request DELETE 'https://api.learnamp.com/v1/tasks/1' \
+--header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
+```
+
+```ruby
+module Learnamp
+  class Tasks
+    include HTTParty
+    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+
+    attr_accessor :token
+
+    def initialize(token)
+      @token = token
+    end
+
+    def delete(id)
+      response = self.class.delete("/tasks/#{id}", { headers: headers })
+      response.parsed_response
+    end
+
+    private
+
+    def headers
+      {
+        'Authorization' => "Bearer #{token}"
+      }
+    end
+  end
+end
+
+Learnamp::Tasks.new(token).delete(2456)
+```
+
+Delete a task. The task is removed from the user's active tasks, and any access that was granted by the task (for example, access to a channel) is revoked.
+
+This matches deleting a task in the UI: the task is given a lifecycle of 'deleted' rather than being permanently destroyed, so it can still be retrieved using the `filters[lifecycle]=deleted` filter on the [View All Tasks](#view-all-tasks) endpoint. Processing the deletion may take a couple of minutes.
+
+`DELETE https://{API_BASE_URL}/v1/tasks/{taskId}`
+
+### Required Scope
+This endpoint requires the `tasks:delete` scope.
+
+> 204 No Content - successful response:
+
+```json
+
+```
+
+> 404 Not Found - unsuccessful response:
+
+```json
+{
+    "error": "Not found"
+}
+```


### PR DESCRIPTION
## Jira

[LA-36971](https://learnamp.atlassian.net/browse/LA-36971) (sub-task of [LA-36517](https://learnamp.atlassian.net/browse/LA-36517))

## What

Documents the new `DELETE /v1/tasks/:id` endpoint (Tasks section), added in learnamp/learnamp#23768.

Adds a **Delete a Task** entry with cURL + Ruby examples, the required `tasks:delete` scope, and 204 / 404 responses — matching the existing Delete a User / Delete a Team docs.

## Why

Customers (Winc Academy, ArcticWolf — see LA-36517) need to delete tasks via the API. The docs note that this is a soft delete (lifecycle becomes `deleted`, retrievable via `filters[lifecycle]=deleted`) and that associated access is revoked, consistent with the UI.

## Anything Else

Pairs with the app PR learnamp/learnamp#23768 — merge/deploy docs once that ships.


[LA-36971]: https://learnamp.atlassian.net/browse/LA-36971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LA-36517]: https://learnamp.atlassian.net/browse/LA-36517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change in API reference; no runtime or security behavior is modified in this repo.
> 
> **Overview**
> Adds a **Delete a Task** section to the Tasks API docs for `DELETE /v1/tasks/{taskId}`, aligned with existing delete endpoints (e.g. Delete a User / Delete a Team).
> 
> The new entry includes cURL and Ruby client examples, documents the **`tasks:delete`** scope, and describes **204 No Content** and **404 Not Found** responses. It explains that deletion is a **soft delete** (lifecycle `deleted`, still listable via `filters[lifecycle]=deleted` on View All Tasks), revokes access granted by the task, and may take a few minutes to process—matching UI behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1318cb5e92be1562aaea15a14768120ec3eb4f99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->