### PR TITLE
[LA-37396] Document fr-CA and ca language codes

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -1177,6 +1177,7 @@ Code | Language
 `es` | Spanish
 `es-CO` | Colombian Spanish
 `fr` | French
+`fr-CA` | Canadian French
 `it` | Italian
 `nl` | Dutch
 `pt-BR` | Brazilian Portuguese
@@ -1190,6 +1191,7 @@ Code | Language
 `ja` | Japanese
 `ar` | Arabic
 `sk` | Slovak
+`ca` | Catalan
 `cy` | Welsh
 `el` | Greek
 `hu` | Hungarian


### PR DESCRIPTION
## Jira
[LA-37396](https://learnamp.atlassian.net/browse/LA-37396)

## What
Adds two newly-supported language codes to the **Supported Language Codes** table on the User API docs:

| Code | Language |
| --- | --- |
| `fr-CA` | Canadian French |
| `ca` | Catalan |

## Why
Both locales were recently added to Learn Amp's `I18n.available_locales` ([fr-CA](https://github.com/learnamp/learnamp/pull/24142) in LA-37396, [ca](https://github.com/learnamp/learnamp/pull/23676) in LA-36833) and are now accepted by the `language` field on the Create/Update User endpoints — but the docs table was missing them. Entries are inserted in the same order as the canonical locale whitelist (`fr-CA` after `fr`, `ca` after `sk`).

## Anything else?
Docs-only change. Naming follows the table's existing editorial style (e.g. "Colombian Spanish", "European Portuguese").


[LA-37396]: https://learnamp.atlassian.net/browse/LA-37396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to a reference table; no runtime or API behavior changes.
> 
> **Overview**
> Updates the User API **Supported Language Codes** table so it matches locales the platform already accepts on Create/Update User `language`.
> 
> Adds **`fr-CA`** (Canadian French) immediately after **`fr`**, and **`ca`** (Catalan) after **`sk`**, using the same naming style as the rest of the table (e.g. Colombian Spanish).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab7cab73fea1f1eb097156e092577ac099ea17f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->