### PR TITLE
Adds pending_deactivation as a possible filter status for API

### DIFF
--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -71,7 +71,7 @@ filters[role] | viewer | Return users with matching role. <br />Possible values:
 filters[status] | *[confirmed,invite_pending]* or *confirmed* | Return users matching any of the given statuses.<br /><br />Param can be an array of statuses, or a string of comma separated statuses.<br />Possible values: "not_invited", "invite_scheduled", "invite_pending", "confirmed", "deactivated"
 filters[no_team] | true | Return users that have no team assigned
 filters[team_ids] | *[1,2,3]* or *1,2,3* | Return members of any of the given teams by team ID.<br /><br />Param can be array of team ids, or a string of comma seperated team ids
-filters[status][] | confirmed | Return users matching any of the given statuses. Repeat the param to pass multiple, e.g. `filters[status][]=confirmed&filters[status][]=deactivated`.<br /><br />Possible values: "not_invited", "invite_scheduled", "invite_pending", "confirmed", "deactivated"
+filters[status][] | confirmed | Return users matching any of the given statuses. Repeat the param to pass multiple, e.g. `filters[status][]=confirmed&filters[status][]=deactivated`.<br /><br />Possible values: "not_invited", "invite_scheduled", "invite_pending", "confirmed", "pending_deactivation", "deactivated"
 filters[created_at][from] | "2021-12-31" | Created date range FROM date in ISO 8601 format
 filters[created_at][to] | "2022-02-28" | Created date range TO date in ISO 8601 format
 filters[updated_at][from] | "2021-12-31" | Updated date range FROM date in ISO 8601 format


### PR DESCRIPTION
Adds `pending_deactivation` as an acceptible user status for the status filer on the users#index endpoint