### PR TITLE
Replace references to hard coded URLs thoughout docs

### DIFF
--- a/source/includes/_activities.md
+++ b/source/includes/_activities.md
@@ -18,7 +18,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/activities' \
 module Learnamp
   class Tasks
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_activities.md
+++ b/source/includes/_activities.md
@@ -10,7 +10,7 @@ All activity records are associated to a User. They contain a [verb](#verbs), li
 > View all activity in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/activities' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/activities' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_authentication.md
+++ b/source/includes/_authentication.md
@@ -3,7 +3,7 @@
 > Generate an Access Token from the Auth Token URL:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/oauth/token' \
+curl --location --request POST 'https://{API_BASE_URL}/oauth/token' \
 --form 'client_id=YOUR-CLIENT-ID' \
 --form 'client_secret=YOUR-CLIENT-SECRET' \
 --form 'grant_type=client_credentials'
@@ -25,7 +25,7 @@ module Learnamp
     end
   end
 end
-
+-
 response = Learnamp::Auth.access_token
 puts response["access_token"] if response.ok?
 ```
@@ -43,13 +43,10 @@ puts response["access_token"] if response.ok?
 
 The Learn Amp API is secured using the OAuth2 Client Credentials flow.
 
-Before calls can be made to the API, an **access token** must be retrieved from the Auth Token URL.
+Before calls can be made to the API, an **access token** must be retrieved from the Auth Token URL:
 
-For accounts on EU1 Pod, the authentication URL is:
-`POST https://api.learnamp.com/oauth/token`
+`POST https://{API_BASE_URL}/oauth/token`
 
-For accounts on EU2 Pod, the authentication URL is:
-`POST https://api-eu2.learnamp.com/oauth/token`
 
 ### Data in Body
 
@@ -125,7 +122,7 @@ roles:read | Read access to roles
 To request specific scopes, add the `scope` parameter to your token request:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/oauth/token' \
+curl --location --request POST 'https://{API_BASE_URL}/oauth/token' \
 --form 'client_id=YOUR-CLIENT-ID' \
 --form 'client_secret=YOUR-CLIENT-SECRET' \
 --form 'grant_type=client_credentials' \

--- a/source/includes/_channels.md
+++ b/source/includes/_channels.md
@@ -17,7 +17,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/channels' \
 module Learnamp
   class Channels
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -82,7 +82,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/channels/123/users_prog
 module Learnamp
   class Channels
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_channels.md
+++ b/source/includes/_channels.md
@@ -9,7 +9,7 @@ In Learn Amp, a Channel is a collection of content (items, learnlists, events et
 > View all channels in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/channels' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/channels' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -74,7 +74,7 @@ Response will be paginated [see pagination](#pagination)
 > View progress of all assigned users through a specified channel:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/channels/123/users_progress' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/channels/123/users_progress' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_communities.md
+++ b/source/includes/_communities.md
@@ -5,7 +5,7 @@
 > For a given community, view all posts
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/communities/123/posts' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/communities/123/posts' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_communities.md
+++ b/source/includes/_communities.md
@@ -13,7 +13,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/communities/123/posts' 
 module Learnamp
   class CommunityPosts
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_enrollments.md
+++ b/source/includes/_enrollments.md
@@ -17,7 +17,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/enrollments' \
 module Learnamp
   class Enrollments
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -166,7 +166,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/events/1' \
 module Learnamp
   class Events
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -283,7 +283,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/enrollments/52' \
 module Learnamp
   class Enrollments
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -410,7 +410,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/enrollments' \
 module Learnamp
   class Enrollments
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_enrollments.md
+++ b/source/includes/_enrollments.md
@@ -9,7 +9,7 @@ In Learn Amp, an Enrollment is the association between a user and an event sessi
 > View all event session enrollments in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/enrollments' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/enrollments' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -158,7 +158,7 @@ filters[updated_at][to] | 2020-04-01 | Enrollment updated date range TO in ISO 8
 > Display details for a single event:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/events/1' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/events/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -275,7 +275,7 @@ This endpoint requires the `events:read` scope.
 > Show a specific enrollment:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/enrollments/52' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/enrollments/52' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -396,7 +396,7 @@ This endpoint requires the `enrollments:read` scope.
 > Create a new enrollment:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/enrollments' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/enrollments' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --header 'Content-Type: application/json' \
 --data-raw '{

--- a/source/includes/_events.md
+++ b/source/includes/_events.md
@@ -13,7 +13,7 @@ After an event session has been completed, the user's attendance is marked. If t
 > View all events in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/events' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/events' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -116,7 +116,7 @@ filters[created_at][to] | "2022-02-28" | Created at date range TO date in ISO 86
 > Display details for a single event:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/events/1' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/events/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_events.md
+++ b/source/includes/_events.md
@@ -21,7 +21,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/events' \
 module Learnamp
   class Events
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -124,7 +124,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/events/1' \
 module Learnamp
   class Events
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_items.md
+++ b/source/includes/_items.md
@@ -9,7 +9,7 @@ Items are typically organised into Channels and Learnlists.
 > View all items in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/items' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/items' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -97,7 +97,7 @@ Each item includes `createdAt`, `updatedAt`, `addedBy` and `tags`. `addedBy` con
 > Display details for a single Item:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/items/3015' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/items/3015' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -206,7 +206,7 @@ This endpoint requires the `items:read` scope.
 > List the learnlists that contain a single item:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/items/3015/learnlists' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/items/3015/learnlists' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -278,7 +278,7 @@ Response will be paginated [see pagination](#pagination)
 > List the channels that contain a single item:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/items/3015/channels' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/items/3015/channels' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -349,7 +349,7 @@ Response will be paginated [see pagination](#pagination)
 > Create a new Item:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/items' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/items' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --form 'url=https://www.test.com' \
 --form 'description=This is the description' \
@@ -514,7 +514,7 @@ The above mentioned parameters `sourceType` and `sourceId` are used to link the 
 > Update an Item:
 
 ```shell
-curl --location --request PUT 'https://api.learnamp.com/v1/items/383' \
+curl --location --request PUT 'https://{API_BASE_URL}/v1/items/383' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --form 'title=New Item Title'
 ```
@@ -646,7 +646,7 @@ archive | true | If item must be archived, set to true. To unarchive an item set
 
 ```shell
 # Complete by item ID
-curl --location --request POST 'https://api.learnamp.com/v1/items/complete' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/items/complete' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --data-raw '{
@@ -655,7 +655,7 @@ curl --location --request POST 'https://api.learnamp.com/v1/items/complete' \
 }'
 
 # Complete by source type and ID
-curl --location --request POST 'https://api.learnamp.com/v1/items/complete' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/items/complete' \
 --header 'Content-Type: application/json' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --data-raw '{
@@ -788,7 +788,7 @@ The response will be an Activity object representing the completion.
 > Delete an item:
 
 ```shell
-curl --location --request DELETE 'https://api.learnamp.com/v1/items/1' \
+curl --location --request DELETE 'https://{API_BASE_URL}/v1/items/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_items.md
+++ b/source/includes/_items.md
@@ -17,7 +17,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/items' \
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -105,7 +105,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/items/3015' \
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -214,7 +214,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/items/3015/learnlists' 
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -286,7 +286,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/items/3015/channels' \
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -362,7 +362,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/items' \
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -523,7 +523,7 @@ curl --location --request PUT 'https://{API_BASE_URL}/v1/items/383' \
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -669,7 +669,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/items/complete' \
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -796,7 +796,7 @@ curl --location --request DELETE 'https://{API_BASE_URL}/v1/items/1' \
 module Learnamp
   class Items
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_learnlists.md
+++ b/source/includes/_learnlists.md
@@ -9,7 +9,7 @@ In Learn Amp, a Learnlist is a 'playlist' of content. It can be structured, like
 > View all learnlists in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/learnlists' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/learnlists' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -75,7 +75,7 @@ Response will be paginated [see pagination](#pagination)
 > Display details for a single Learnlist:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/learnlists/379' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/learnlists/379' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -139,7 +139,7 @@ This endpoint requires the `learnlists:read` scope.
 > List the contents of a single Learnlist:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/learnlists/379/contents' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/learnlists/379/contents' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_learnlists.md
+++ b/source/includes/_learnlists.md
@@ -17,7 +17,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/learnlists' \
 module Learnamp
   class Learnlists
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -83,7 +83,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/learnlists/379' \
 module Learnamp
   class Learnlists
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -147,7 +147,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/learnlists/379/contents
 module Learnamp
   class Learnlists
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_surveys.md
+++ b/source/includes/_surveys.md
@@ -15,7 +15,7 @@ When a survey is `anonymous`, responses are returned without the respondent (`us
 > View all surveys in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/surveys' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/surveys' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -87,7 +87,7 @@ Response will be paginated [see pagination](#pagination)
 > Display details for a single survey:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/surveys/379' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/surveys/379' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -158,7 +158,7 @@ This endpoint requires the `surveys:read` scope.
 > List all submitted responses for a single survey:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/surveys/379/responses' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/surveys/379/responses' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_surveys.md
+++ b/source/includes/_surveys.md
@@ -23,7 +23,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/surveys' \
 module Learnamp
   class Surveys
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -95,7 +95,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/surveys/379' \
 module Learnamp
   class Surveys
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -166,7 +166,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/surveys/379/responses' 
 module Learnamp
   class Surveys
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_tasks.md
+++ b/source/includes/_tasks.md
@@ -17,7 +17,7 @@ Tasks may be expired, for example, if the same user is required to complete the 
 > View all tasks in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/tasks' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/tasks' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -285,7 +285,7 @@ filters[lifecycle] | "active,deleted,deactivated" | Lifecycle status of task. Ca
 > Delete a task:
 
 ```shell
-curl --location --request DELETE 'https://api.learnamp.com/v1/tasks/1' \
+curl --location --request DELETE 'https://{API_BASE_URL}/v1/tasks/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_tasks.md
+++ b/source/includes/_tasks.md
@@ -25,7 +25,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/tasks' \
 module Learnamp
   class Tasks
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -293,7 +293,7 @@ curl --location --request DELETE 'https://{API_BASE_URL}/v1/tasks/1' \
 module Learnamp
   class Tasks
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_team_users.md
+++ b/source/includes/_team_users.md
@@ -5,7 +5,7 @@
 > View all users for a given team:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/teams/1/users' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/teams/1/users' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -143,7 +143,7 @@ Response will be paginated [see pagination](#pagination)
 > Add a user to a team:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/teams/1/users' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/teams/1/users' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -325,7 +325,7 @@ response | Teams::Simple | Optional: (blank value is the default) or "Teams::Sim
 > Add a user to a team by email and team name:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/teams/users' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/teams/users' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -511,7 +511,7 @@ Exactly one of `teamId`, `teamName`, or `teamIntegrationExternalId` must be pres
 > Remove a user from a team:
 
 ```shell
-curl --location --request DELETE 'https://api.learnamp.com/v1/teams/1/users/1' \
+curl --location --request DELETE 'https://{API_BASE_URL}/v1/teams/1/users/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -576,7 +576,7 @@ This endpoint requires the `team_users:delete` scope.
 > Add multiple users to a team:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/teams/1/bulk/users' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/teams/1/bulk/users' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --header 'Content-Type: application/json' \
 --data-raw '{

--- a/source/includes/_team_users.md
+++ b/source/includes/_team_users.md
@@ -13,7 +13,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/teams/1/users' \
 module Learnamp
   class TeamUsers
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -156,7 +156,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/teams/1/users' \
 module Learnamp
   class TeamUsers
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -338,7 +338,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/teams/users' \
 module Learnamp
   class TeamUsers
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -519,7 +519,7 @@ curl --location --request DELETE 'https://{API_BASE_URL}/v1/teams/1/users/1' \
 module Learnamp
   class TeamUsers
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -589,7 +589,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/teams/1/bulk/users' \
 module Learnamp
   class TeamUsers
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_teams.md
+++ b/source/includes/_teams.md
@@ -9,7 +9,7 @@ In Learn Amp, a Team is any grouping of users. Teams may map to your organisatio
 > View all teams in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/teams' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/teams' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -124,7 +124,7 @@ filters[tags] | "developers,product,compliance" | Return teams matching any of t
 > Display details for a single Team:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/teams/383' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/teams/383' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -287,7 +287,7 @@ The same subroute supports `PUT` and `DELETE` with identical behaviour to the id
 > Create a new Team:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/teams' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/teams' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --form 'name=New Team Test' \
 --form 'managerId=1' \
@@ -295,7 +295,7 @@ curl --location --request POST 'https://api.learnamp.com/v1/teams' \
 ```
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/teams' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/teams' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --form 'name=New Team Test' \
 --form 'managerEmail=manager@company.com' \
@@ -442,7 +442,7 @@ Same rule applies for `parentTeamId` - `parentTeamName` and `subTeamIds` - `subT
 > Update a team:
 
 ```shell
-curl --location --request PUT 'https://api.learnamp.com/v1/teams/383' \
+curl --location --request PUT 'https://{API_BASE_URL}/v1/teams/383' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --form 'name=New Team Name' \
 --form 'managerId=1'
@@ -634,7 +634,7 @@ response | Simple | Optional: Either "Simple" (default) or "Extended". Value of 
 > Delete a team:
 
 ```shell
-curl --location --request DELETE 'https://api.learnamp.com/v1/teams/1' \
+curl --location --request DELETE 'https://{API_BASE_URL}/v1/teams/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_teams.md
+++ b/source/includes/_teams.md
@@ -17,7 +17,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/teams' \
 module Learnamp
   class Teams
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -132,7 +132,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/teams/383' \
 module Learnamp
   class Teams
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -307,7 +307,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/teams' \
 module Learnamp
   class Teams
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -452,7 +452,7 @@ curl --location --request PUT 'https://{API_BASE_URL}/v1/teams/383' \
 module Learnamp
   class Teams
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -642,7 +642,7 @@ curl --location --request DELETE 'https://{API_BASE_URL}/v1/teams/1' \
 module Learnamp
   class Teams
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -10,7 +10,7 @@ In Learn Amp, a User, is a person who can access the platform. User's belong to 
 > View all users in your account:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/users' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/users' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -178,7 +178,7 @@ filters[deactivated_at][to] | "2022-02-28" | Deactivated date range TO date in I
 > Display details for a single user:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/users/1' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/users/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -299,7 +299,7 @@ This endpoint requires the `users:read` scope.
 > Display details for a single user, looked up by integration external ID:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/users/by_integration_external_id/EPOS-12345' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/users/by_integration_external_id/EPOS-12345' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -424,7 +424,7 @@ This endpoint requires the `users:read` scope.
 > Create a new user in your account:
 
 ```shell
-curl --location --request POST 'https://api.learnamp.com/v1/users' \
+curl --location --request POST 'https://{API_BASE_URL}/v1/users' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --form 'email=testuser@test.com' \
 --form 'firstName=Test' \
@@ -646,7 +646,7 @@ customFields | [{ name: "Employee ID", value: "12-34-56" }] | CustomFields param
 > Update an existing user:
 
 ```shell
-curl --location --request PUT 'https://api.learnamp.com/v1/users/1382' \
+curl --location --request PUT 'https://{API_BASE_URL}/v1/users/1382' \
 --header 'Authorization: Bearer SQn9nZAxgwPJcz-neajmNahBdlc2DRoNbUHwx9A4Rvw' \
 --form 'firstName=Jim' \
 --form 'lastName=Robinson' \
@@ -892,7 +892,7 @@ A user may also be updated by `integrationExternalId` via a dedicated subroute â
 > Update an existing user, looked up by `integrationExternalId`:
 
 ```shell
-curl --location --request PUT 'https://api.learnamp.com/v1/users/by_integration_external_id/EPOS-12345' \
+curl --location --request PUT 'https://{API_BASE_URL}/v1/users/by_integration_external_id/EPOS-12345' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN' \
 --form 'jobTitle=Senior Developer' \
 --form 'location=Edinburgh'
@@ -1005,7 +1005,7 @@ Accepts the same body parameters as [Update a User](#update-a-user), including `
 > Deactivate a user:
 
 ```shell
-curl --location --request PUT 'https://api.learnamp.com/v1/users/1/deactivate' \
+curl --location --request PUT 'https://{API_BASE_URL}/v1/users/1/deactivate' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -1065,7 +1065,7 @@ This endpoint requires the `users:deactivate` scope.
 > Reactivate a deactivated user:
 
 ```shell
-curl --location --request PUT 'https://api.learnamp.com/v1/users/1/reactivate' \
+curl --location --request PUT 'https://{API_BASE_URL}/v1/users/1/reactivate' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -1125,7 +1125,7 @@ This endpoint requires the `users:reactivate` scope.
 > Delete a user:
 
 ```shell
-curl --location --request DELETE 'https://api.learnamp.com/v1/users/1' \
+curl --location --request DELETE 'https://{API_BASE_URL}/v1/users/1' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 
@@ -1185,7 +1185,7 @@ This endpoint requires the `users:delete` scope.
 > View progress of all assigned channels by the specified user:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/users/567/channels_progress' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/users/567/channels_progress' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_users.md
+++ b/source/includes/_users.md
@@ -18,7 +18,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/users' \
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -186,7 +186,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/users/1' \
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -307,7 +307,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/users/by_integration_ex
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -443,7 +443,7 @@ curl --location --request POST 'https://{API_BASE_URL}/v1/users' \
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -662,7 +662,7 @@ curl --location --request PUT 'https://{API_BASE_URL}/v1/users/1382' \
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -902,7 +902,7 @@ curl --location --request PUT 'https://{API_BASE_URL}/v1/users/by_integration_ex
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -1013,7 +1013,7 @@ curl --location --request PUT 'https://{API_BASE_URL}/v1/users/1/deactivate' \
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -1073,7 +1073,7 @@ curl --location --request PUT 'https://{API_BASE_URL}/v1/users/1/reactivate' \
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -1133,7 +1133,7 @@ curl --location --request DELETE 'https://{API_BASE_URL}/v1/users/1' \
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 
@@ -1193,7 +1193,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/users/567/channels_prog
 module Learnamp
   class Users
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/includes/_verbs.md
+++ b/source/includes/_verbs.md
@@ -9,7 +9,7 @@ In Learn Amp, each Activity has an associated Verb. Verbs are a concept in the T
 > View all available verbs:
 
 ```shell
-curl --location --request GET 'https://api.learnamp.com/v1/verbs' \
+curl --location --request GET 'https://{API_BASE_URL}/v1/verbs' \
 --header 'Authorization: Bearer YOUR-ACCESS-TOKEN'
 ```
 

--- a/source/includes/_verbs.md
+++ b/source/includes/_verbs.md
@@ -17,7 +17,7 @@ curl --location --request GET 'https://{API_BASE_URL}/v1/verbs' \
 module Learnamp
   class Verbs
     include HTTParty
-    base_uri "#{ENV['BASE_URL']}#{ENV['API_PATH']}"
+    base_uri "#{ENV['API_BASE_URL']}/v1"
 
     attr_accessor :token
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -42,7 +42,7 @@ To get started, you will need:
 
 1. An account on the Learn Amp platform
 2. An API Key and Secret: Go to "Company Settings" --> "API" --> "Generate New API Key"
-3. Take note of the API Base URL, and use this value for all API calls.
+3. Take note of the **API Base URL**, and use this value for all API calls. All examples in this documentation use {API_BASE_URL} which can be replaced with the value listed in your company Settings API area.
 
 **Please note** Only the Owner user of your account is permitted to access the API settings.
 
@@ -51,24 +51,14 @@ To get started, you will need:
 
 ## Authentication Token URL
 
-For accounts on EU1 Pod:
 ```
-https://api.learnamp.com/oauth/token
-```
-
-For accounts on EU2 Pod:
-```
-https://api-eu2.learnamp.com/oauth/token
+https://{API_BASE_URL}/oauth/token
 ```
 
 ## API Base URL for subsquent calls
 
-For accounts on EU1 Pod:
 ```
-https://api.learnamp.com/v1
+https://{API_BASE_URL}/v1
 ```
 
-For accounts on EU2 Pod:
-```
-https://api-eu2.learnamp.com/v1
-```
+


### PR DESCRIPTION
To avoid publically exposing the full API endpoints, and also to guard against having to update docs every time we add a new pod, this change replaces hard coded references to our API endpoints, with `{API_BASE_URL}` everywhere

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL templating; no runtime or API behavior changes.
> 
> **Overview**
> Replaces **pod-specific** Learn Amp API hosts (`api.learnamp.com`, `api-eu2.learnamp.com`) across the Slate docs with a single **`{API_BASE_URL}`** placeholder in curl examples, inline endpoint URLs, and the Getting Started / auth sections on `index.html.md.erb`.
> 
> Ruby HTTParty samples for resource clients now use **`base_uri "#{ENV['API_BASE_URL']}/v1"`** instead of **`BASE_URL` + `API_PATH`**. Authentication prose drops separate EU1/EU2 URL blocks in favor of one templated OAuth and API base pattern, with Getting Started clarifying that readers should substitute the value from Company Settings → API.
> 
> **Note:** Auth Ruby snippets still reference `ENV['BASE_URL']` for OAuth; that was not updated in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7fae740f3267aa3824f3883a9a003a13c57bc3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->