### PR TITLE
Small tweak to move URLs into the body

### DIFF
--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -51,14 +51,8 @@ To get started, you will need:
 
 ## Authentication Token URL
 
-```
-https://{API_BASE_URL}/oauth/token
-```
+`https://{API_BASE_URL}/oauth/token`
 
 ## API Base URL for subsquent calls
 
-```
-https://{API_BASE_URL}/v1
-```
-
-
+`https://{API_BASE_URL}/v1`


### PR DESCRIPTION
Moves the example URLS in the Getting Started section so they appear in the content body 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only formatting in `index.html.md.erb` with no runtime or API behavior impact.
> 
> **Overview**
> Updates the **Getting Started** section on the API reference landing page so the **Authentication Token URL** and **API Base URL** are shown as inline `` `https://{API_BASE_URL}/...` `` text instead of fenced code blocks.
> 
> This aligns those two URLs with how endpoint URLs are presented elsewhere in the docs (e.g. authentication), and removes extra blank lines after the base URL block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 894055491b61aeb1652d686a1261bd9fa9050f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->